### PR TITLE
docs: add volcengine-voice community plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ cp hermes-plugins/evey_utils.py ~/.hermes/plugins/
 | **evey-digest** | Daily digest compilation from multiple data sources. |
 | **evey-delegation-score** | Score and rank delegation results for quality tracking. |
 
+### Community Plugins
+
+Plugins maintained by the Hermes community:
+
+| Plugin | Author | Description |
+|--------|--------|-------------|
+| **[volcengine-voice](https://github.com/linxichen/hermes-volcengine-voice)** | [@linxichen](https://github.com/linxichen) | Volcengine (火山引擎) Doubao TTS + STT — 60+ Chinese voices, dialect support, speaker diarization. |
+
 ### Shared
 | File | What It Does |
 |------|-------------|


### PR DESCRIPTION
Adds linxichen/hermes-volcengine-voice to the Community Plugins section.

**What it is:** A Volcengine (火山引擎) Doubao TTS + STT plugin for Hermes Agent. Supports 60+ Chinese voice options, dialect recognition, and speaker diarization. Full voice pipeline — TTS for speech synthesis and STT for voice transcription via WebSocket binary protocol.

**Repo:** https://github.com/linxichen/hermes-volcengine-voice
**Blog tutorial:** https://linxic.com/tutorial/hermes-volcengine-voice-plugin/